### PR TITLE
Fix : PWA install not showing up

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,6 +273,7 @@
     "postworkflow:migrate:text-sets": "npx prettier --write packages/text-sets/src/raw",
     "workflow:migrate:templates": "npm run migration --workspace packages/migration packages/templates/src/raw",
     "postworkflow:migrate:templates": "npx prettier --write packages/templates/src/raw",
+    "pwa:build": "NODE_ENV=production webpack --config webpack.playground.config.cjs",
     "predeploy": "NODE_ENV=production APP_ENV=ghpages webpack --config webpack.playground.config.cjs",
     "deploy": "gh-pages -d build/playground --repo git@github.com:rtCamp/web-story-creation-tool.git",
     "workflow:migrate:ftue-story": "npm run migration --workspace packages/migration includes/data/stories",

--- a/packages/playground-story-editor/src/editor.js
+++ b/packages/playground-story-editor/src/editor.js
@@ -27,6 +27,8 @@ import CreationTool from './components/creationTool';
 import { StoryStatusProvider, useStoryStatus } from './app/storyStatus';
 import useIndexedDBMedia from './app/IndexedDBMedia/useIndexedDBMedia';
 
+registerServiceWorker();
+
 const AppContainer = styled.div`
   height: ${({ isMobile }) => {
     return isMobile ? window?.innerHeight + 'px' : '100vh';
@@ -65,7 +67,6 @@ render(
 );
 
 if ('loading' === document.readyState) {
-  registerServiceWorker();
   document.addEventListener('DOMContentLoaded', initEditor);
 } else {
   initEditor();

--- a/packages/playground-story-editor/src/index.js
+++ b/packages/playground-story-editor/src/index.js
@@ -26,6 +26,8 @@ import { StoryStatusProvider, useStoryStatus } from './app/storyStatus';
 import Dashboard from './components/dashboard';
 import useIndexedDBMedia from './app/IndexedDBMedia/useIndexedDBMedia';
 
+registerServiceWorker();
+
 const App = () => {
   useIndexedDBMedia();
   const { isInitializingIndexDB, isRefreshingMedia } = useStoryStatus(
@@ -51,7 +53,6 @@ const initDashboard = () => {
 };
 
 if ('loading' === document.readyState) {
-  registerServiceWorker();
   document.addEventListener('DOMContentLoaded', initDashboard);
 } else {
   initDashboard();


### PR DESCRIPTION
TL;DR
- Move `registerServiceWorker` function call to the top level to fix the race condition.
- Add a new npm command to build PWA for local use - `npm run pwa:build`

------------------------------------------------------------------
I suspect the service worker is not registered. 

Currently, the service worker is registered in entry JS files ( index.js and editor.js ) on a simple condition that if `document.readyState` is `loading` then install the service worker. It might be the case that the `document.readyState` does not have the value `loading` when entry JS files are being executed.

Therefore registering  the service worker on the top level fixes the issue. 
